### PR TITLE
Adjust location of the TUW logo so that it is like in the TUW PowerPoint template

### DIFF
--- a/tuw/beamerthemetuw.sty
+++ b/tuw/beamerthemetuw.sty
@@ -192,7 +192,7 @@
     \ifbeamer@tuwWhiteLogo % white logo option specified
     \node[anchor=north west] (logo) at (0.3cm,\paperheight-0.1cm) {\includegraphics[height=2cm]{\beamer@tuwLogoWhite}};
     \else
-    \node[anchor=north west] (logo) at (0.3cm,\paperheight-0.1cm) {\includegraphics[height=2cm]{\beamer@tuwLogo}};
+    \node[anchor=north west] (logo) at (0.2cm,\paperheight-0.2cm) {\includegraphics[height=2cm]{\beamer@tuwLogo}};
     \fi
     % content page
     \ifnum\thepage>1\relax%


### PR DESCRIPTION
The logo was located differently than in the PowerPoint template and it had different margins from the left and top edge of the title slide. Now it has the same margin from both edges and is at the same location like in the official PowerPoint template.